### PR TITLE
Fix maven goal in maven_args

### DIFF
--- a/.github/workflows/maven-verify-with-its.yml
+++ b/.github/workflows/maven-verify-with-its.yml
@@ -23,7 +23,7 @@ on:
       maven_args:
         description: The arguments to pass to Maven when building the code
         required: false
-        default: --errors --batch-mode --show-version -P run-its -D"invoker.streamLogsOnFailures" verify
+        default: --errors --batch-mode --show-version -P run-its -D"invoker.streamLogsOnFailures"
         type: string
 
       os-matrix:
@@ -92,7 +92,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn ${{ inputs.maven_args }}
+        run: mvn ${{ inputs.maven_args }} verify
 
       - name: Build Maven Site
         run: mvn ${{ inputs.maven_args }} site


### PR DESCRIPTION
When we have maven goal `verify` in `maven_args` site test will be run as

```

mvn ... verify site

```

so we run `verify` twice