### PR TITLE
Simplify fail fast configuration - 3 

### DIFF
--- a/.github/workflows/maven-verify-with-its.yml
+++ b/.github/workflows/maven-verify-with-its.yml
@@ -50,40 +50,31 @@ on:
         default: '[ "temurin" ]'
         type: string
 
+      # fail fast job setup
+      ff-os:
+        description: The os used during fail-fast-build job
+        required: false
+        default: 'ubuntu-latest'
+        type: string
+
+      ff-jdk:
+        description: The jdk version used during fail-fast-build job
+        required: false
+        default: '8'
+        type: string
+
+      ff-jdk-distribution:
+        description: The jdk distribution used during fail-fast-build job
+        required: false
+        default: 'temurin'
+        type: string
+
 jobs:
 
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-
-    outputs:
-      ff-os: ${{ steps.setup.outputs.ff-os }}
-      ff-jdk: ${{ steps.setup.outputs.ff-jdk }}
-      ff-jdk-distribution: ${{ steps.setup.outputs.ff-jdk-distribution }}
-      ff-excludes: ${{ steps.excludes.outputs.ff-excludes }}
-
-    steps:
-      # get first items from matrix for fail-fast
-      - id: setup
-        run: |
-          echo '::set-output name=ff-os::${{ fromJSON( inputs.os-matrix )[0] }}'
-          echo '::set-output name=ff-jdk::${{ fromJSON( inputs.jdk-matrix )[0] }}'
-          echo '::set-output name=ff-jdk-distribution::${{ fromJSON( inputs.jdk-distribution-matrix )[0] }}'
-
-      # prepare excludes for verify matrix in order to not run the same build twice
-      - id: excludes
-        run: |
-          EXCLUDES=$(echo '${{ inputs.matrix-exclude }}' | jq -rc '. + [{
-            "os": "${{ steps.setup.outputs.ff-os }}",
-            "jdk": "${{ steps.setup.outputs.ff-jdk }}",
-            "distribution": "${{ steps.setup.outputs.ff-jdk-distribution }}"
-          }]')
-          echo "::set-output name=ff-excludes::$EXCLUDES"
-
-  build:
-    needs: setup
-    name: ${{ needs.setup.outputs.ff-os }} jdk-${{ needs.setup.outputs.ff-jdk }}-${{ needs.setup.outputs.ff-jdk-distribution }}
-    runs-on: ${{ needs.setup.outputs.ff-os }}
+  # verify build on one node - before matrix will start
+  fail-fast-build:
+    name: ${{ inputs.ff-os }} jdk-${{ inputs.ff-jdk }}-${{ inputs.ff-jdk-distribution }}
+    runs-on: ${{ inputs.ff-os }}
 
     steps:
       - name: Checkout
@@ -92,15 +83,15 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2.3.1
         with:
-          java-version: ${{ needs.setup.outputs.ff-jdk }}
-          distribution: ${{ needs.setup.outputs.ff-jdk-distribution }}
+          java-version: ${{ inputs.ff-jdk }}
+          distribution: ${{ inputs.ff-jdk-distribution }}
           cache: 'maven'
 
       - name: Build with Maven
         run: mvn ${{ inputs.maven_args }} verify
 
   verify:
-    needs: [ setup, build ]
+    needs: fail-fast-build
     name: ${{ matrix.os }} jdk-${{ matrix.jdk }}-${{ matrix.distribution }}
 
     runs-on: ${{ matrix.os }}
@@ -111,7 +102,7 @@ jobs:
         os: ${{ fromJSON( inputs.os-matrix ) }}
         jdk: ${{ fromJSON( inputs.jdk-matrix ) }}
         distribution: ${{ fromJSON( inputs.jdk-distribution-matrix ) }}
-        exclude: ${{ fromJSON( needs.setup.outputs.ff-excludes ) }}
+        exclude: ${{ fromJSON( inputs.matrix-exclude ) }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## it is draft - please don't merge - we have 3 propositions to choose

- add fail-fast input parameters
- no condition on job in matrix, the same job - fatst-build  and in matrix will be run, we will have the same job run twice sometime it can be long job especially for a plugin with plenty of its