### PR TITLE
Move common flags from maven_args to steps command

### DIFF
--- a/.github/workflows/maven-verify-with-its.yml
+++ b/.github/workflows/maven-verify-with-its.yml
@@ -23,7 +23,7 @@ on:
       maven_args:
         description: The arguments to pass to Maven when building the code
         required: false
-        default: --errors --batch-mode --show-version -P run-its -D"invoker.streamLogsOnFailures"
+        default: -P run-its -D"invoker.streamLogsOnFailures"
         type: string
 
       os-matrix:
@@ -97,7 +97,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn ${{ inputs.maven_args }} verify
+        run: mvn --errors --batch-mode --show-version ${{ inputs.maven_args }} verify
 
   verify:
     needs: [ setup, build ]
@@ -125,7 +125,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn ${{ inputs.maven_args }} verify
+        run: mvn --errors --batch-mode --show-version ${{ inputs.maven_args }} verify
 
       - name: Build Maven Site
-        run: mvn ${{ inputs.maven_args }} site
+        run: mvn --errors --batch-mode --show-version ${{ inputs.maven_args }} site


### PR DESCRIPTION
This change allow simpler use with other project than maven, which require different profileseg, we can

```yml
uses: apache/maven-gh-actions-shared/....
with:
   maven_args: '-Pdocs'
```
