### PR TITLE
Execute test on proper branch

### DIFF
--- a/.github/workflows/maven-verify-with-its-test.yml
+++ b/.github/workflows/maven-verify-with-its-test.yml
@@ -15,9 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Verify
+name: Verify Test - main
 
-on: push
+on:
+  push:
+    branches:
+    - main
 
 jobs:
   build:


### PR DESCRIPTION
Test has static  reference for branch,
so should be executed on corresponding branch