### PR TITLE
[SCM-988] Ensure all images have Git, Svn and Mercurial

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -221,7 +221,6 @@ jobs:
       - name: Ensure all needed tools are installed (macOS)
         if: steps.should-run.conclusion == 'success' && matrix.os == 'macOS-latest'
         run: |
-          brew update
           brew install mercurial
 
       - name: Show free disk space

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -214,6 +214,16 @@ jobs:
           inputs.verify-site-goal != inputs.ff-site-goal
         run: echo ok
 
+      # Some projects (like maven-scm) need the commandline tools for all SCMs installed.
+      # Git and SVN are installed on all by default.
+      # Mercurial is not installed on macOS.
+      # https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-macos-runners
+      - name: Ensure all needed tools are installed (macOS)
+        if: steps.should-run.conclusion == 'success' && matrix.os == 'macOS-latest'
+        run: |
+          brew update
+          brew install mercurial
+
       - name: Show free disk space
         if: steps.should-run.conclusion == 'success'
         run: df -h


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SCM-988

Not all tests for maven-scm can run on all platforms because mercurial (hg) is not installed on macOS in the default `macOS-latest` image provided by Github.

**NOTE: I am unable to test if this change actually works**

CC: @michael-o 
