### PR TITLE
[SCM-988] Make installing mercurial optional

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -128,6 +128,12 @@ on:
         required: false
         type: string
 
+      install-mercurial:
+        description: Ensure all build images have Mercurial(hg) installed
+        required: false
+        default: false
+        type: boolean
+
 # allow single build per branch or PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -218,8 +224,11 @@ jobs:
       # Git and Subversion are installed on all by default.
       # Mercurial is not installed on macOS.
       # https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-macos-runners
-      - name: Ensure all needed tools are installed (macOS)
-        if: steps.should-run.conclusion == 'success' && matrix.os == 'macOS-latest'
+      - name: Install Mercurial (hg) on macOS
+        if: >
+          inputs.install-mercurial && 
+          steps.should-run.conclusion == 'success' && 
+          matrix.os == 'macOS-latest'
         run: |
           brew install mercurial
 


### PR DESCRIPTION
This is the flag that was missing from my previous pull request https://github.com/apache/maven-gh-actions-shared/pull/44 .

If a project needs mercurial to be installed they can now use this config
```
jobs:
  build:
    name: Verify
    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
    with:
      install-mercurial: true
```

I have tested this by updating the config on my fork of maven-scm and use in that project
```
    uses: nielsbasjes/maven-gh-actions-shared/.github/workflows/maven-verify.yml@SCM-988-OptionalInstallMercurial
```

Then both projects are in my namespace and the Github Actions fully runs where the log show mercurial was actually present.
