### PR TITLE
Matrix build with many Maven versions

### DIFF
--- a/.github/workflows/maven-verify-test.yml
+++ b/.github/workflows/maven-verify-test.yml
@@ -17,7 +17,7 @@
 
 name: Verify - Test
 
-on: push
+on: [ push, pull_request ]
 
 jobs:
 
@@ -32,3 +32,4 @@ jobs:
       ff-goal: test
       verify-goal: clean install
       verify-fail-fast: false
+      maven-matrix: '[ "3.2.5", "3.8.6" ]'

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -20,53 +20,53 @@ name: Verify
 on:
   workflow_call:
     inputs:
-      maven_args:
+      maven-args:
         description: The arguments to pass to all Maven commands when building the code
         required: false
         default: '-D"invoker.streamLogsOnFailures"'
         type: string
 
-      maven_version:
-        description: The Maven version used for builds
-        required: false
-        default: '3.8.6'
-        type: string
-
       os-matrix:
-        description: 'os matrix as json array'
+        description: os matrix as json array
         required: false
         default: '[ "ubuntu-latest", "windows-latest", "macOS-latest" ]'
         type: string
 
       jdk-matrix:
-        description: 'jdk matrix as json array'
+        description: jdk matrix as json array
         required: false
         default: '[ "8", "11", "17" ]'
         type: string
 
+      jdk-distribution-matrix:
+        description: jdk distribution matrix
+        required: false
+        default: '[ "temurin" ]'
+        type: string
+
+      maven-matrix:
+        description: The Maven version matrix as json array
+        required: false
+        default: '[ "3.8.6" ]'
+        type: string
+
       matrix-exclude:
-        description: 'exclude for matrix as json'
+        description: exclude for matrix as json
         required: false
         default: '[]'
         type: string
 
       max-parallel:
-        description: 'max parallel jobs'
+        description: max parallel jobs
         required: false
         default: 100
         type: number
 
       timeout-minutes:
-        description: 'timeout-minutes used by the builds (defaults to 360)'
+        description: timeout-minutes used by the builds (defaults to 360)
         required: false
         default: 360
         type: number
-
-      jdk-distribution-matrix:
-        description: "jdk distribution matrix"
-        required: false
-        default: '[ "temurin" ]'
-        type: string
 
       # fail fast job setup
       ff-run:
@@ -79,6 +79,12 @@ on:
         description: The os used during fail-fast-build job
         required: false
         default: 'ubuntu-latest'
+        type: string
+
+      ff-maven:
+        description: The Maven version used during fail-fast-build job
+        required: false
+        default: '3.8.6'
         type: string
 
       ff-jdk:
@@ -112,7 +118,7 @@ on:
         type: string
 
       ff-timeout-minutes:
-        description: 'timeout-minutes used by fail-fast-build jobs (defaults to 360)'
+        description: timeout-minutes used by fail-fast-build jobs (defaults to 360)
         required: false
         default: 360
         type: number
@@ -121,12 +127,6 @@ on:
         description: The Maven goal used by verfy jobs
         required: false
         default: '-P run-its verify'
-        type: string
-
-      verify-site-goal:
-        description: The Maven goal used by verfy jobs to build site
-        required: false
-        default: '-DskipTests -P reporting site'
         type: string
 
       verify-fail-fast:
@@ -155,7 +155,7 @@ jobs:
 
   # verify build on one node - before matrix will start
   fail-fast-build:
-    name: ${{ inputs.ff-os }} jdk-${{ inputs.ff-jdk }}-${{ inputs.ff-jdk-distribution }}
+    name: ${{ inputs.ff-os }} jdk-${{ inputs.ff-jdk }}-${{ inputs.ff-jdk-distribution }} ${{ inputs.ff-maven }}
     runs-on: ${{ inputs.ff-os }}
     timeout-minutes: ${{ inputs.ff-timeout-minutes }}
     # execute on any push or pull request from forked repo
@@ -179,13 +179,14 @@ jobs:
           cache: 'maven'
 
       - name: Set up Maven
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.1.0:wrapper "-Dmaven=${{ inputs.maven_version }}"
+        run:
+          mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.1.0:wrapper "-Dmaven=${{ inputs.ff-maven }}"
 
       - name: Build with Maven
-        run: ./mvnw --errors --batch-mode --show-version ${{ inputs.maven_args }} ${{ inputs.ff-goal }}
+        run: ./mvnw --errors --batch-mode --show-version ${{ inputs.maven-args }} ${{ inputs.ff-goal }}
 
       - name: Build Maven Site
-        run: ./mvnw --errors --batch-mode --show-version ${{ inputs.maven_args }} ${{ inputs.ff-site-goal }}
+        run: ./mvnw --errors --batch-mode --show-version ${{ inputs.maven-args }} ${{ inputs.ff-site-goal }}
         if: inputs.ff-site-run
 
       - name: Upload Maven Site
@@ -209,7 +210,7 @@ jobs:
 
   verify:
     needs: fail-fast-build
-    name: ${{ matrix.os }} jdk-${{ matrix.jdk }}-${{ matrix.distribution }}
+    name: ${{ matrix.os }} jdk-${{ matrix.jdk }}-${{ matrix.distribution }} ${{ matrix.maven }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     runs-on: ${{ matrix.os }}
     if: always() && ( !inputs.ff-run || needs.fail-fast-build.result == 'success' )
@@ -220,6 +221,7 @@ jobs:
         os: ${{ fromJSON( inputs.os-matrix ) }}
         jdk: ${{ fromJSON( inputs.jdk-matrix ) }}
         distribution: ${{ fromJSON( inputs.jdk-distribution-matrix ) }}
+        maven: ${{ fromJSON( inputs.maven-matrix ) }}
         exclude: ${{ fromJSON( inputs.matrix-exclude ) }}
       max-parallel: ${{ inputs.max-parallel }}
 
@@ -230,8 +232,8 @@ jobs:
           matrix.os != inputs.ff-os ||
           matrix.jdk != inputs.ff-jdk ||
           matrix.distribution != inputs.ff-jdk-distribution ||
-          inputs.verify-goal != inputs.ff-goal ||
-          inputs.verify-site-goal != inputs.ff-site-goal
+          matrix.maven != inputs.ff-maven ||
+          inputs.verify-goal != inputs.ff-goal
         run: echo ok
 
       # Some projects (like Maven SCM) need the command-line tools for all SCMs installed.
@@ -267,11 +269,11 @@ jobs:
 
       - name: Set up Maven
         if: steps.should-run.conclusion == 'success'
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.1.0:wrapper "-Dmaven=${{ inputs.maven_version }}"
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.1.0:wrapper "-Dmaven=${{ matrix.maven }}"
 
       - name: Build with Maven
         if: steps.should-run.conclusion == 'success'
-        run: ./mvnw --errors --batch-mode --show-version ${{ inputs.maven_args }} ${{ inputs.verify-goal }}
+        run: ./mvnw --errors --batch-mode --show-version ${{ inputs.maven-args }} ${{ inputs.verify-goal }}
 
       - name: Upload artifact on failure
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### break compatibility

 - replace `maven_version` by  `maven-matrix` and `ff-maven`
 - remove not used `verify-site-goal`
 - rename `maven_args` to `maven-args`
 