### PR TITLE
Use Java 17 as default. Remove Java 11 from ci

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -35,7 +35,7 @@ on:
       jdk-matrix:
         description: jdk matrix as json array
         required: false
-        default: '[ "8", "11", "17" ]'
+        default: '[ "8", "17" ]'
         type: string
 
       jdk-distribution-matrix:
@@ -90,7 +90,7 @@ on:
       ff-jdk:
         description: The jdk version used during fail-fast-build job
         required: false
-        default: '11'
+        default: '17'
         type: string
 
       ff-jdk-distribution:


### PR DESCRIPTION
We recommend to use latest LTS Java version.