### PR TITLE
Skip Maven Site testing on second executions

### DIFF
--- a/.github/workflows/maven-verify-test.yml
+++ b/.github/workflows/maven-verify-test.yml
@@ -30,6 +30,7 @@ jobs:
     uses: ./.github/workflows/maven-verify.yml
     needs: verify-1
     with:
+      ff-site-run: false
       ff-goal: test
       verify-goal: clean install
       verify-fail-fast: false

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -197,6 +197,7 @@ jobs:
 
       - name: Upload Maven Site
         uses: actions/upload-artifact@v3
+        if: inputs.ff-site-run
         with:
           name: ${{ github.run_number }}-site-${{ inputs.ff-os }}-${{ inputs.ff-jdk }}-${{ inputs.ff-jdk-distribution }}
           path: |


### PR DESCRIPTION
New version of actions/upload-artifact requires unique name of uploaded artifacts