### PR TITLE
Apply ASF Infra GitHub Actions Policy

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -65,7 +65,7 @@ on:
       max-parallel:
         description: max parallel jobs
         required: false
-        default: 100
+        default: 20
         type: number
 
       timeout-minutes:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,6 +28,6 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348  # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- max-parallel as 20 - most of our project use 18
- pin version of release-drafter

https://infra.apache.org/github-actions-policy.html