### PR TITLE
Skip release-drafter on release commits

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,6 +33,9 @@ concurrency: release-drafter
 
 jobs:
   detect-version:
+    # skip release drafter on releases commits
+    if: (!startsWith(github.event.head_commit.message , '[maven-release-plugin]'))
+
     name: Detect version
     runs-on: ubuntu-latest
     permissions: {}


### PR DESCRIPTION
We should preserve last generated release notes.