### PR TITLE
Add PR number to concurrency definition in pr-automation

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -27,8 +27,8 @@ on:
 
 # allow single build per branch or PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: false
 
 # clare all permissions for GITHUB_TOKEN
 permissions: {}


### PR DESCRIPTION
We need explicit add PR number to concurrency definition 
`pull_request_target` event set GITHUB_REF set to PR base branch

https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target