### PR TITLE
Add skip-changelog label

### DIFF
--- a/.github/labels.js
+++ b/.github/labels.js
@@ -67,6 +67,11 @@ module.exports = [
         description: ""
     },
     {
+        name: "skip-changelog",
+        color: "e4e669",
+        description: "Skip this PR from automatically changelog generation"
+    },
+    {
         name: "priority:blocker",
         color: "cc0000",
         description: "Blocks development and/or testing work, production could not run"


### PR DESCRIPTION
Will allow to skip PR from changelog generated by release drafter

There is used in https://github.com/apache/maven-gh-actions-shared/blob/92f0dd6ffddd8e7254da046dc72696f988bbf4cb/.github/release-drafter.yml#L71-L76