### PR TITLE
Skip release drafter only on the next development version

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -34,7 +34,7 @@ concurrency: release-drafter
 jobs:
   detect-version:
     # skip release drafter on releases commits
-    if: (!startsWith(github.event.head_commit.message , '[maven-release-plugin]'))
+    if: (!startsWith(github.event.head_commit.message , '[maven-release-plugin] prepare for next development iteration'))
 
     name: Detect version
     runs-on: ubuntu-latest


### PR DESCRIPTION
Release drafter should refresh the draft with the current release version