### PR TITLE
Update auto label to skip-changelog

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -22,7 +22,7 @@ on:
       default-label:
         description: The default label to add to PR
         required: false
-        default: 'maintenance'
+        default: 'skip-changelog'
         type: string
 
 # allow single build per branch or PR


### PR DESCRIPTION
Currently, with auto-labelling to maintenance, we have a lot of noise in release notes containing useless changes for the end user