### PR TITLE
Add comment to merged PR with missing label

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -149,11 +149,20 @@ jobs:
       toJSON(github.event.pull_request.labels) == '[]'
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR labels
-        if: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name) == '' }}
-        run: |
-          echo "::error::PRs must be labeled"
-          exit 1
+      - name: Comment PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: '@' + context.payload.pull_request.merged_by.login +
+              ' Please assign appropriate label to PR according to the type of change.'
+            });
+
+            throw new Error('PRs must be labeled');
 
   # check PR assignee - if no one is assigned, assign to person who merge PR
   assignees:


### PR DESCRIPTION
Now condition `github.event_name == 'pull_request'` is wrong ... and step is always skipped.

I would like to add a comment with mention user who merge a PR, that label is required.