### PR TITLE
Remove dependabot in old branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,24 +20,6 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "v1"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "v2"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "v3"
-    schedule:
-      interval: "daily"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
     target-branch: "v4"
     schedule:
       interval: "daily"


### PR DESCRIPTION
We use v4 only