### PR TITLE
Maven 3.8 EOL - run CI only on 3.9.x

### DIFF
--- a/.github/workflows/maven-verify-test.yml
+++ b/.github/workflows/maven-verify-test.yml
@@ -37,7 +37,7 @@ jobs:
       ff-jdk: '21'
       verify-goal: clean install
       verify-fail-fast: false
-      maven-matrix: '[ "3.9.11", "3.8.9", "3.6.3" ]'
+      maven-matrix: '[ "3.9.11" ]'
 
   # test with Maven 4
   verify-3:

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -47,7 +47,7 @@ on:
       maven-matrix:
         description: The Maven version matrix as json array
         required: false
-        default: '[ "3.6.3", "3.9.11" ]'
+        default: '[ "3.9.11" ]'
         type: string
 
       maven4-version:


### PR DESCRIPTION
https://github.com/apache/maven-site/pull/842

https://lists.apache.org/thread/gdyhw6mt6qhnbknpngpkj8s4ckx7s7xs

Will allow to save on GHA resource usages