### PR TITLE
Protect release-drafter branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,7 @@ github:
     v2: { }
     v3: { }
     v4: { }
+    release-drafter: { } # fork of release-drafter,  waiting for PR merge release-drafter/release-drafter#1451
   pull_requests:
     del_branch_on_merge: true
   features:


### PR DESCRIPTION
As this branch is used by our release-drafter jobs, should be also protected to avoid accidentally removed

ref:
 - https://github.com/apache/maven-gh-actions-shared/issues/210
 - https://github.com/apache/maven-gh-actions-shared/pull/189