### PR TITLE
Add Temurin to JDK matrix

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -41,7 +41,7 @@ on:
       jdk-distribution-matrix:
         description: jdk distribution matrix
         required: false
-        default: '[ "zulu" ]'
+        default: '[ "temurin", "zulu" ]'
         type: string
 
       maven-matrix:


### PR DESCRIPTION
Topic came up in Maven JMod Plugin.
Temurin seems to be more strict implementing JEPs. Having multiple JDKs in the pipeline increases chances of noticing errors due different implementations.