### PR TITLE
Unprotect release-drafter branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,6 @@ github:
     v2: { }
     v3: { }
     v4: { }
-    release-drafter: { } # fork of release-drafter,  waiting for PR merge release-drafter/release-drafter#1451
   pull_requests:
     del_branch_on_merge: true
   features:


### PR DESCRIPTION
As we use official version of release drafter, we cen remove workaround branch

references:
 - https://github.com/apache/maven-gh-actions-shared/pull/230
 - https://github.com/apache/maven-gh-actions-shared/pull/211
 - https://github.com/apache/maven-gh-actions-shared/pull/189