### PR TITLE
feat: Install and make available all LTS JDK versions via Toolchains.

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -32,6 +32,17 @@ on:
         default: '[ "ubuntu-latest", "windows-latest", "macos-latest" ]'
         type: string
 
+      jdk-toolchain:
+        description: 'The jdk versions to be present in the maven toolchain (default: all current LTS versions)'
+        required: false
+        default: |
+            8
+            11
+            17
+            21
+            25
+        type: string
+
       jdk-matrix:
         description: jdk matrix as json array
         required: false
@@ -117,6 +128,17 @@ on:
         default: '3.9.14'
         type: string
 
+      ff-jdk-toolchain:
+        description: 'The jdk versions to be present in the maven toolchain during fail-fast-build job (default: all current LTS versions)'
+        required: false
+        default: |
+          8
+          11
+          17
+          21
+          25
+        type: string
+
       ff-jdk:
         description: The jdk version used during fail-fast-build job
         required: false
@@ -193,7 +215,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# clare all permissions for GITHUB_TOKEN
+# clear all permissions for GITHUB_TOKEN
 permissions: {}
 
 jobs:
@@ -273,6 +295,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Set up JDKs for Toolchain
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.ff-jdk-toolchain }}
+          distribution: ${{ inputs.ff-jdk-distribution }}
+          cache: 'maven'
 
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -390,6 +419,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Set up JDKs for Toolchain
+        if: steps.should-run.conclusion == 'success'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: ${{ inputs.jdk-toolchain }}
+          distribution: ${{ matrix.distribution }}
+          cache: 'maven'
 
       - name: Set up JDK
         if: steps.should-run.conclusion == 'success'

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,31 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <target>
+                <echo message="Current Java Version: ${java.version}" />
+                <echo message="Java Home           : ${java.home}" />
+                <echo message="Contents of toolchains.xml:" />
+                <concat>
+                  <file name="${user.home}/.m2/toolchains.xml" />
+                </concat>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
There are situations where tests in projects need the availability of different JDKs that are then used via maven toolchains.
At this time there is no way to add them in a project.
This change (**CURRENTLY UNTESTED**) proposes using this feature https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#installing-multiple-jdks-with-toolchains to add all LTS JDK versions to be available during every build.
