### PR TITLE
Use cache only for last setup-java step

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -301,7 +301,6 @@ jobs:
         with:
           java-version: ${{ inputs.ff-jdk-toolchain }}
           distribution: ${{ inputs.ff-jdk-distribution }}
-          cache: 'maven'
 
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -426,7 +425,6 @@ jobs:
         with:
           java-version: ${{ inputs.jdk-toolchain }}
           distribution: ${{ matrix.distribution }}
-          cache: 'maven'
 
       - name: Set up JDK
         if: steps.should-run.conclusion == 'success'


### PR DESCRIPTION
As we have execute step setup-java twice, for all JDK with toolchain and last for default JDK 
cache can be used only on last one to avoid twice download cache file