### PR TITLE
fix: Drop JDK 8 from default toolchains because of poor availability

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -36,7 +36,6 @@ on:
         description: 'The jdk versions to be present in the maven toolchain (default: all current LTS versions)'
         required: false
         default: |
-            8
             11
             17
             21
@@ -132,7 +131,6 @@ on:
         description: 'The jdk versions to be present in the maven toolchain during fail-fast-build job (default: all current LTS versions)'
         required: false
         default: |
-          8
           11
           17
           21


### PR DESCRIPTION
Using this to build the javadoc plugin showed that multiple platforms no longer have Java 8.
https://github.com/apache/maven-javadoc-plugin/actions/runs/23333153502/job/67868796597?pr=1309

My proposal is to simply remove java 8 from the default toolchains.

@slawekjaranowski I hope this fixes it.