### PR TITLE
remove version-template from release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,7 +18,6 @@
 # Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
 name-template: $RESOLVED_VERSION
 tag-template: v$RESOLVED_VERSION
-version-template: $COMPLETE
 
 filter-by-commitish: true
 


### PR DESCRIPTION
Simplifies the configuration by removing an unnecessary template, we use version option with release-drafter, so this option is ignored

Additionally in V7 template `$COMPLETE` is not exist