### PR TITLE
Apply maven-args to the Set up Maven step

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -317,7 +317,7 @@ jobs:
 
       - name: Set up Maven
         run:
-          mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=${{ needs.setup-maven-version.outputs.version }}"
+          mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper ${{ inputs.maven-args }} "-Dmaven=${{ needs.setup-maven-version.outputs.version }}"
 
       - name: Build with Maven
         run: ./mvnw --errors --batch-mode --show-version ${{ inputs.maven-args }} ${{ inputs.ff-goal }}
@@ -443,7 +443,7 @@ jobs:
 
       - name: Set up Maven
         if: steps.should-run.conclusion == 'success'
-        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=${{ matrix.maven }}"
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper ${{ inputs.maven-args }} "-Dmaven=${{ matrix.maven }}"
 
       - name: Build with Maven
         if: steps.should-run.conclusion == 'success'


### PR DESCRIPTION
## Problem

The `Set up Maven` step bootstraps the Maven wrapper by running the runner's
*system* `mvn` against `maven-wrapper-plugin:wrapper`:

```yaml
- name: Set up Maven
  run: mvn … maven-wrapper-plugin:3.3.4:wrapper "-Dmaven=${{ matrix.maven }}"
```

Running any goal in a project directory forces Maven to read the project model,
which includes **resolving the parent POM** — even though the goal itself only
writes wrapper files. This step does **not** pass `${{ inputs.maven-args }}`,
unlike the later `Build with Maven` / `Build Maven Site` steps.

So a caller that injects a custom settings file via `maven-args`
(e.g. `-s .github/settings.xml` to reach a *staged* Apache parent POM during a
simultaneous Apache-parent / project-parent vote) cannot influence parent
resolution in this first step. The bootstrap then fails with
`Non-resolvable parent POM … org.apache:apache:pom:39 … in central` before the
actual build ever runs.

Concrete failure: apache/maven-parent#578 →
https://github.com/apache/maven-parent/actions/runs/28279903879/job/83793460535

## Fix

Pass `${{ inputs.maven-args }}` to the wrapper bootstrap in both the
`fail-fast-build` and `verify` jobs. The default value
(`-D"invoker.streamLogsOnFailures"`) is benign, so this is a no-op for callers
that do not set `maven-args`.