### PR TITLE
Fix GnuPG PATH on Windows for Gpg4win 5.x

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -406,7 +406,10 @@ jobs:
           $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin"
           [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
           choco install --yes gpg4win
-          echo "C:\Program Files (x86)\Gpg4win\..\GnuPG\bin" >> $env:GITHUB_PATH
+          # Gpg4win 4.x (32-bit) deploys GnuPG under "Program Files (x86)", 5.x+ (64-bit) under "Program Files"
+          "C:\Program Files\GnuPG\bin", "C:\Program Files (x86)\GnuPG\bin" |
+            Where-Object { Test-Path $_ } |
+            Add-Content $env:GITHUB_PATH
 
       - name: Check GnuPG
         if: >


### PR DESCRIPTION
## Problem

Every Windows job using `install-gpg: true` currently fails signing (see e.g. [maven-gpg-plugin Verify runs](https://github.com/apache/maven-gpg-plugin/actions/runs/29223244178/job/86733435698) — failing on master and every PR):

```
gpg: keyblock resource '/d/a/.../target/it/no-main-artifact/D:\\a\\...\\target\\test-classes\\gnupg/pubring.kbx': No such file or directory
gpg: signing failed: No secret key
```

## Root cause

Chocolatey now installs **Gpg4win 5.x, which is 64-bit** and deploys GnuPG to `C:\Program Files\GnuPG` — the install log shows `Deployed to 'C:\Program Files\Gpg4win\..\GnuPG'`. The workflow's hardcoded PATH entry `C:\Program Files (x86)\Gpg4win\..\GnuPG\bin` matches the old 32-bit Gpg4win 4.x layout and no longer exists.

As a result the freshly installed native GnuPG never lands on PATH, and `gpg` resolves to the MSYS build bundled with Git for Windows on the runner image (visible in the *Check GnuPG* step output: `Home: /c/Users/runneradmin/.gnupg`). MSYS gpg interprets Windows-style absolute paths passed via `--homedir` (`D:\a\...`) as *relative* POSIX paths and prepends the cwd, so keyrings are never found and all signing integration tests fail.

## Fix

After `choco install gpg4win`, add whichever GnuPG bin directory actually exists to `GITHUB_PATH`, covering both the 4.x (`Program Files (x86)`) and 5.x (`Program Files`) layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)