### PR TITLE
Add v5 to Dependabot and ASF configuration

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,7 @@ github:
     v2: { }
     v3: { }
     v4: { }
+    v5: { }
   pull_requests:
     del_branch_on_merge: true
   features:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,18 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "v5"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "v5"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     target-branch: "v4"
     schedule:
       interval: "daily"


### PR DESCRIPTION
- Enabled daily updates for GitHub Actions and Maven in v5.
- Marked v5 as a protected branch in ASF YAML.