### PR TITLE
Default Maven 4 version to 4.0.0-rc-6

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -63,7 +63,7 @@ on:
       maven4-version:
         description: The Maven 4.x version matrix
         required: false
-        default: '4.0.0-rc-5'
+        default: '4.0.0-rc-6'
         type: string
 
       maven4-enabled:


### PR DESCRIPTION
4.0.0-rc-6 is released, so repositories that do not override `maven4-version` now build against the current RC by default.

Companion PR for `v5` — the two branches carry the identical change and should land together.

Verified: `Verify - Test` green on the fork before opening.
